### PR TITLE
added gatekeeper mutating webhook

### DIFF
--- a/kubernetes/31-opa-gatekeeper-setup.sh
+++ b/kubernetes/31-opa-gatekeeper-setup.sh
@@ -13,4 +13,4 @@ kubectl create namespace gatekeeper --dry-run=client -o yaml | kubectl apply -f 
 kubectl create secret generic regcred --type=kubernetes.io/dockerconfigjson --from-file=.dockerconfigjson=$DOCKER_CONFIG_JSON -n gatekeeper  --dry-run=client -o yaml | kubectl apply -f -
 
 helm repo add gatekeeper https://open-policy-agent.github.io/gatekeeper/charts
-helm upgrade --install gatekeeper gatekeeper/gatekeeper -n gatekeeper
+helm upgrade -f enable-mutating.yaml --install gatekeeper gatekeeper/gatekeeper -n gatekeeper

--- a/kubernetes/enable-mutating.yaml
+++ b/kubernetes/enable-mutating.yaml
@@ -1,0 +1,1 @@
+experimentalEnableMutation: true

--- a/kubernetes/tekton-resources/demo/image-verification/templates/gatekeeper-mutating.yaml
+++ b/kubernetes/tekton-resources/demo/image-verification/templates/gatekeeper-mutating.yaml
@@ -1,0 +1,16 @@
+apiVersion: mutations.gatekeeper.sh/v1alpha1
+kind: AssignMetadata
+metadata:
+  name: annotation-salsa
+spec:
+  match:
+    scope: Namespaced
+    kinds:
+    - apiGroups: ["*"]
+      kinds: ["Pod"]
+    namespaces:
+      - "prod"
+  location: "metadata.annotations.salsa"
+  parameters:
+    assign:
+      value: "verified"


### PR DESCRIPTION
Enabled mutating webhook for gatekeeper such that we can add in labels and annotations. It can also be used to enforce and change properties as Secure Supply chains needs.