### PR TITLE
Update brew installation of tektoncd-cli

### DIFF
--- a/kubernetes/00-kubernetes-minikube-setup.sh
+++ b/kubernetes/00-kubernetes-minikube-setup.sh
@@ -17,8 +17,7 @@ case "${PLATFORM}" in
   Darwin)
     minikube version || brew install minikube
     helm version || brew install helm
-    brew tap tektoncd/tools
-    tkn version || brew install tektoncd/tools/tektoncd-cli
+    tkn version || brew install tektoncd-cli
     ;;
 
   Linux)


### PR DESCRIPTION
The previous brew installation is out-of-date. As per https://github.com/tektoncd/homebrew-tools:
```
brew untap tektoncd/tools
brew install tektoncd-cli
```