### PR TITLE
Add how to read content from attestation to example

### DIFF
--- a/examples/buildpacks/README.md
+++ b/examples/buildpacks/README.md
@@ -45,6 +45,9 @@ crane ls "${DOCKER_IMG}"
 # Verify the image and the attestation.
 cosign verify --key k8s://tekton-chains/signing-secrets "${DOCKER_IMG}"
 cosign verify-attestation --key k8s://tekton-chains/signing-secrets "${DOCKER_IMG}"
+
+# Read the content of the attesation
+cosign verify-attestation --key k8s://tekton-chains/signing-secrets "${DOCKER_IMG}" | jq .payload | tr -d '"' | base64 --decode | jq
 ```
 
 ## Links

--- a/examples/buildpacks/README.md
+++ b/examples/buildpacks/README.md
@@ -47,7 +47,7 @@ cosign verify --key k8s://tekton-chains/signing-secrets "${DOCKER_IMG}"
 cosign verify-attestation --key k8s://tekton-chains/signing-secrets "${DOCKER_IMG}"
 
 # Read the content of the attesation
-cosign verify-attestation --key k8s://tekton-chains/signing-secrets "${DOCKER_IMG}" | jq .payload | tr -d '"' | base64 --decode | jq
+cosign download attestation "${DOCKER_IMG}" | jq -r .payload | base64 --decode | jq
 ```
 
 ## Links


### PR DESCRIPTION
Minor update to add an example of how you can base64 decode an
attestation for the purposes of reading the content.