### PR TITLE
Fix IMAGE_URL usage by crane

### DIFF
--- a/.github/workflows/install-ssf.yaml
+++ b/.github/workflows/install-ssf.yaml
@@ -54,7 +54,7 @@ jobs:
           tkn pr logs --last -f
           sleep 60
           export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
-          docker run --rm gcr.io/go-containerregistry/crane ls "$(sed 's|:[^/]*$||' <<< ${IMAGE_URL})"
+          docker run --rm gcr.io/go-containerregistry/crane ls "$(echo -n ${IMAGE_URL} | sed 's|:[^/]*$||')"
           tkn tr describe --last -o json | jq -r '.metadata.annotations["chains.tekton.dev/signed"]'
           cosign verify --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
           cosign verify-attestation --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
@@ -64,7 +64,7 @@ jobs:
           tkn pr logs --last -f
           sleep 60
           export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
-          docker run --rm gcr.io/go-containerregistry/crane ls "$(sed 's|:[^/]*$||' <<< ${IMAGE_URL})"
+          docker run --rm gcr.io/go-containerregistry/crane ls "$(echo -n ${IMAGE_URL} | sed 's|:[^/]*$||')"
 
           cosign verify --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
           cosign verify-attestation --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"

--- a/.github/workflows/install-ssf.yaml
+++ b/.github/workflows/install-ssf.yaml
@@ -54,7 +54,7 @@ jobs:
           tkn pr logs --last -f
           sleep 60
           export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
-          docker run --rm gcr.io/go-containerregistry/crane ls "${IMAGE_URL%:*}"
+          docker run --rm gcr.io/go-containerregistry/crane ls "$(sed 's|:[^/]*$||' <<< ${IMAGE_URL})"
           tkn tr describe --last -o json | jq -r '.metadata.annotations["chains.tekton.dev/signed"]'
           cosign verify --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
           cosign verify-attestation --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
@@ -64,7 +64,7 @@ jobs:
           tkn pr logs --last -f
           sleep 60
           export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r '.[] | select(.name | match("IMAGE_URL$")) | .value')
-          docker run --rm gcr.io/go-containerregistry/crane ls "${IMAGE_URL%:*}"
+          docker run --rm gcr.io/go-containerregistry/crane ls "$(sed 's|:[^/]*$||' <<< ${IMAGE_URL})"
 
           cosign verify --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"
           cosign verify-attestation --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"

--- a/docs/content/docs/getting-started/quick-start.md
+++ b/docs/content/docs/getting-started/quick-start.md
@@ -100,7 +100,7 @@ tkn tr describe --last -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/s
 #### Ensure the attestation and the signature were uploaded to OCI
 
 ```bash
-crane ls "$(sed 's|:[^/]*$||' <<< ${IMAGE_URL})"
+crane ls "$(echo -n ${IMAGE_URL} | sed 's|:[^/]*$||')"
 ```
 
 The output should look similar to this:

--- a/docs/content/docs/getting-started/quick-start.md
+++ b/docs/content/docs/getting-started/quick-start.md
@@ -100,7 +100,7 @@ tkn tr describe --last -o jsonpath='{.metadata.annotations.chains\.tekton\.dev/s
 #### Ensure the attestation and the signature were uploaded to OCI
 
 ```bash
-crane ls "${IMAGE_URL%:*}"
+crane ls "$(sed 's|:[^/]*$||' <<< ${IMAGE_URL})"
 ```
 
 The output should look similar to this:

--- a/examples/buildpacks/README.md
+++ b/examples/buildpacks/README.md
@@ -41,7 +41,7 @@ export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r 
 export TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
 
 # Double check that the attestation and the signature were uploaded to the OCI.
-crane ls "$(sed 's|:[^/]*$||' <<< ${IMAGE_URL})"
+crane ls "$(echo -n ${IMAGE_URL} | sed 's|:[^/]*$||')"
 
 # Verify the image and the attestation.
 cosign verify --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"

--- a/examples/buildpacks/README.md
+++ b/examples/buildpacks/README.md
@@ -41,7 +41,7 @@ export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r 
 export TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
 
 # Double check that the attestation and the signature were uploaded to the OCI.
-crane ls "${IMAGE_URL%:*}"
+crane ls "$(sed 's|:[^/]*$||' <<< ${IMAGE_URL})"
 
 # Verify the image and the attestation.
 cosign verify --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"

--- a/examples/go-pipeline/README.md
+++ b/examples/go-pipeline/README.md
@@ -30,7 +30,7 @@ export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r 
 export TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
 
 # Double check that the attestation and the signature were uploaded to the OCI.
-crane ls "$(sed 's|:[^/]*$||' <<< ${IMAGE_URL})"
+crane ls "$(echo -n ${IMAGE_URL} | sed 's|:[^/]*$||')"
 
 # Verify the image and the attestation.
 cosign verify --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"

--- a/examples/go-pipeline/README.md
+++ b/examples/go-pipeline/README.md
@@ -30,7 +30,7 @@ export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r 
 export TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
 
 # Double check that the attestation and the signature were uploaded to the OCI.
-crane ls "${IMAGE_URL%:*}"
+crane ls "$(sed 's|:[^/]*$||' <<< ${IMAGE_URL})"
 
 # Verify the image and the attestation.
 cosign verify --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"

--- a/examples/ibm-tutorial/README.md
+++ b/examples/ibm-tutorial/README.md
@@ -39,7 +39,7 @@ export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r 
 export TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
 
 # Double check that the attestation and the signature were uploaded to the OCI.
-crane ls "$(sed 's|:[^/]*$||' <<< ${IMAGE_URL})"
+crane ls "$(echo -n ${IMAGE_URL} | sed 's|:[^/]*$||')"
 
 # Verify the image and the attestation.
 cosign verify --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"

--- a/examples/ibm-tutorial/README.md
+++ b/examples/ibm-tutorial/README.md
@@ -39,7 +39,7 @@ export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r 
 export TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
 
 # Double check that the attestation and the signature were uploaded to the OCI.
-crane ls "${IMAGE_URL%:*}"
+crane ls "$(sed 's|:[^/]*$||' <<< ${IMAGE_URL})"
 
 # Verify the image and the attestation.
 cosign verify --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"

--- a/examples/sample-pipeline/README.md
+++ b/examples/sample-pipeline/README.md
@@ -56,7 +56,7 @@ export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r 
 export TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
 
 # Double check that the attestation and the signature were uploaded to the OCI.
-crane ls "$(sed 's|:[^/]*$||' <<< ${IMAGE_URL})"
+crane ls "$(echo -n ${IMAGE_URL} | sed 's|:[^/]*$||')"
 
 # Verify the image and the attestation.
 cosign verify --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"

--- a/examples/sample-pipeline/README.md
+++ b/examples/sample-pipeline/README.md
@@ -56,7 +56,7 @@ export IMAGE_URL=$(tkn pr describe --last -o jsonpath='{..taskResults}' | jq -r 
 export TASK_RUN=$(tkn pr describe --last -o json | jq -r '.status.taskRuns | keys[] as $k | {"k": $k, "v": .[$k]} | select(.v.status.taskResults[]?.name | match("IMAGE_URL$")) | .k')
 
 # Double check that the attestation and the signature were uploaded to the OCI.
-crane ls "${IMAGE_URL%:*}"
+crane ls "$(sed 's|:[^/]*$||' <<< ${IMAGE_URL})"
 
 # Verify the image and the attestation.
 cosign verify --key k8s://tekton-chains/signing-secrets "${IMAGE_URL}"


### PR DESCRIPTION
The existing expression `"${IMAGE_URL%:*}”` did not work correctly when the repository part of the URL contained a `:`. e.g.
```
IMAGE_URL=192.168.1.37:8888/00878d64c6a1c2a58ad06cc9e959c177/slsa
```