### PR TITLE
Updating vendor details for kaniko

### DIFF
--- a/platform/vendor/tekton/catalog/main/task/kaniko/0.6/kaniko.yaml
+++ b/platform/vendor/tekton/catalog/main/task/kaniko/0.6/kaniko.yaml
@@ -62,4 +62,4 @@ spec:
       script: |
         set -e
         image="$(params.IMAGE)"
-        echo "${image}" | tee "$(results.IMAGE_URL.path)"
+        echo -n "${image}" | tee "$(results.IMAGE_URL.path)"

--- a/platform/vendor/vendor.yaml
+++ b/platform/vendor/vendor.yaml
@@ -25,7 +25,7 @@ files:
     validation_type: "sha256"
   - release_file: "https://raw.githubusercontent.com/tektoncd/catalog/main/task/kaniko/0.6/kaniko.yaml"
     destination_dir: "tekton/catalog/main/task/kaniko/0.6"
-    sha256: "92d44e556f64282f3ebc395ae5fa2cc1ea1a3de60177aaeedc49957360280717"
+    sha256: "595746871b33eb6dc84b56b1a94365d8707cbe7fcec91fb02218be834dce504c"
     validation_type: "sha256"
   - release_file: "https://raw.githubusercontent.com/buildpacks/tekton-integration/main/task/buildpacks/0.4/buildpacks.yaml"
     destination_dir: "buildpacks/tekton-integration/main/task/buildpacks/0.4"


### PR DESCRIPTION
The kaniko v0.6 task was updated in place so the contents and hash have changed. This PR updates the vendored YAML file and the hash in the vendor config.

Upstream commit: https://github.com/tektoncd/catalog/commit/ec3af2a2b5c4a57705c9c56ce7254bc839a28463

Signed-off-by: Brad Beck <bradley.beck@gmail.com>