### PR TITLE
Use vendored trivy YAML

### DIFF
--- a/examples/gradle-pipeline/gradle-pipeline.sh
+++ b/examples/gradle-pipeline/gradle-pipeline.sh
@@ -12,7 +12,7 @@ C_RESET_ALL='\033[0m'
 # Install shared tasks.
 kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/git-clone/0.4/git-clone.yaml
 kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/jib-gradle/0.4/jib-gradle.yaml
-kubectl apply -f https://raw.githubusercontent.com/tektoncd/catalog/main/task/trivy-scanner/0.1/trivy-scanner.yaml
+kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/trivy-scanner/0.1/trivy-scanner.yaml
 
 # Install the buildpacks pipelinerun.
 echo -e "${C_GREEN}Creating a Gradle pipelinerun: REPOSITORY=${REPOSITORY}${C_RESET_ALL}"


### PR DESCRIPTION
Use the vendored version of trivy YAML instead of pulling it directly from the Tekton catalog.

Signed-off-by: Brad Beck <bradley.beck@gmail.com>