### PR TITLE
Vendor git-clone v0.6

### DIFF
--- a/examples/buildpacks/buildpacks.sh
+++ b/examples/buildpacks/buildpacks.sh
@@ -10,7 +10,7 @@ C_GREEN='\033[32m'
 C_RESET_ALL='\033[0m'
 
 # Install shared tasks.
-kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/git-clone/0.4/git-clone.yaml
+kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/git-clone/0.6/git-clone.yaml
 kubectl apply -f "${GIT_ROOT}"/platform/vendor/buildpacks/tekton-integration/main/task/buildpacks/0.4/buildpacks.yaml
 kubectl apply -f "${GIT_ROOT}"/platform/vendor/buildpacks/tekton-integration/main/task/buildpacks-phases/0.2/buildpacks-phases.yaml
 

--- a/examples/go-pipeline/go-pipeline.sh
+++ b/examples/go-pipeline/go-pipeline.sh
@@ -10,7 +10,7 @@ C_GREEN='\033[32m'
 C_RESET_ALL='\033[0m'
 
 # Install shared tasks.
-kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/git-clone/0.4/git-clone.yaml
+kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/git-clone/0.6/git-clone.yaml
 kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/golang-build/0.3/golang-build.yaml
 kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/golang-test/0.2/golang-test.yaml
 kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/trivy-scanner/0.1/trivy-scanner.yaml

--- a/examples/gradle-pipeline/gradle-pipeline.sh
+++ b/examples/gradle-pipeline/gradle-pipeline.sh
@@ -10,7 +10,7 @@ C_GREEN='\033[32m'
 C_RESET_ALL='\033[0m'
 
 # Install shared tasks.
-kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/git-clone/0.4/git-clone.yaml
+kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/git-clone/0.6/git-clone.yaml
 kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/jib-gradle/0.4/jib-gradle.yaml
 kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/trivy-scanner/0.1/trivy-scanner.yaml
 

--- a/examples/ibm-tutorial/ibm-tutorial.sh
+++ b/examples/ibm-tutorial/ibm-tutorial.sh
@@ -11,7 +11,7 @@ C_RESET_ALL='\033[0m'
 
 # Create the IBM tutorial pipelinerun.
 echo -e "${C_GREEN}Creating a IBM tutorial pipelinerun: REPOSITORY=${REPOSITORY}${C_RESET_ALL}"
-kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/git-clone/0.4/git-clone.yaml
+kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/git-clone/0.6/git-clone.yaml
 kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/kaniko/0.6/kaniko.yaml
 pushd "${GIT_ROOT}"/examples/ibm-tutorial
 cue cmd -t "repository=${REPOSITORY}" apply | kubectl apply -f -

--- a/examples/maven/maven.sh
+++ b/examples/maven/maven.sh
@@ -10,7 +10,7 @@ C_GREEN='\033[32m'
 C_RESET_ALL='\033[0m'
 
 # Install shared tasks.
-kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/git-clone/0.4/git-clone.yaml
+kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/git-clone/0.6/git-clone.yaml
 kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/maven/0.2/maven.yaml
 
 # Install the maven pipelinerun.

--- a/examples/sample-pipeline/sample-pipeline.sh
+++ b/examples/sample-pipeline/sample-pipeline.sh
@@ -16,7 +16,7 @@ kubectl create sa pipeline-account -n prod --dry-run=client -o yaml | kubectl ap
 
 # Install the sample pipeline.
 echo -e "${C_GREEN}Creating a sample-pipeline: REPOSITORY=${REPOSITORY}${C_RESET_ALL}"
-kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/git-clone/0.4/git-clone.yaml
+kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/git-clone/0.6/git-clone.yaml
 kubectl apply -f "${GIT_ROOT}"/platform/vendor/tekton/catalog/main/task/kaniko/0.6/kaniko.yaml
 pushd "${GIT_ROOT}"/examples/sample-pipeline
 cue cmd -t "repository=${REPOSITORY}" apply | kubectl apply -f -

--- a/platform/vendor/tekton/catalog/main/task/git-clone/0.6/git-clone.yaml
+++ b/platform/vendor/tekton/catalog/main/task/git-clone/0.6/git-clone.yaml
@@ -3,7 +3,7 @@ kind: Task
 metadata:
   name: git-clone
   labels:
-    app.kubernetes.io/version: "0.4"
+    app.kubernetes.io/version: "0.6"
   annotations:
     tekton.dev/pipelines.minVersion: "0.29.0"
     tekton.dev/categories: Git
@@ -39,6 +39,11 @@ spec:
         other files in this Workspace are ignored. It is strongly recommended
         to use ssh-directory over basic-auth whenever possible and to bind a
         Secret to this Workspace over other volume types.
+    - name: ssl-ca-directory
+      optional: true
+      description: |
+        A workspace containing CA certificates, this will be used by Git to
+        verify the peer with when fetching or pushing over HTTPS.
   params:
     - name: url
       description: Repository URL to clone from.
@@ -149,6 +154,10 @@ spec:
         value: $(workspaces.basic-auth.bound)
       - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
         value: $(workspaces.basic-auth.path)
+      - name: WORKSPACE_SSL_CA_DIRECTORY_BOUND
+        value: $(workspaces.ssl-ca-directory.bound)
+      - name: WORKSPACE_SSL_CA_DIRECTORY_PATH
+        value: $(workspaces.ssl-ca-directory.path)
       script: |
         #!/usr/bin/env sh
         set -eu
@@ -156,6 +165,7 @@ spec:
         if [ "${PARAM_VERBOSE}" = "true" ] ; then
           set -x
         fi
+
 
         if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ] ; then
           cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
@@ -170,6 +180,9 @@ spec:
           chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
         fi
 
+        if [ "${WORKSPACE_SSL_CA_DIRECTORY_BOUND}" = "true" ] ; then
+           export GIT_SSL_CAPATH="${WORKSPACE_SSL_CA_DIRECTORY_PATH}"
+        fi
         CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"
 
         cleandir() {

--- a/platform/vendor/vendor.yaml
+++ b/platform/vendor/vendor.yaml
@@ -55,3 +55,7 @@ files:
     destination_dir: "tekton/catalog/main/task/trivy-scanner/0.1"
     sha256: "b43c6ed2eb4b2b04781c2643f139f60345e92504dd20365f4f888a41c45d42b5"
     validation_type: "sha256"
+  - release_file: "https://raw.githubusercontent.com/tektoncd/catalog/main/task/git-clone/0.6/git-clone.yaml"
+    destination_dir: "tekton/catalog/main/task/git-clone/0.6"
+    sha256: "42a0c585d4f0b26e08edd84c5a88684662575ca8e832eea7311a5c8ebf524c45"
+    validation_type: "sha256"


### PR DESCRIPTION
Switch to using the vendored version of git-clone (v0.6) which was updated as part of https://github.com/tektoncd/catalog/pull/858

Signed-off-by: Brad Beck <bradley.beck@gmail.com>