### PR TITLE
Update the homebrew tap for CUE

### DIFF
--- a/platform/00-kubernetes-minikube-setup.sh
+++ b/platform/00-kubernetes-minikube-setup.sh
@@ -60,7 +60,7 @@ case "${PLATFORM}" in
     tkn version || brew install tektoncd-cli
     kubectl version --client || brew install kubectl
     cosign version || brew install sigstore/tap/cosign
-    cue version || brew install cuelang/tap/cue 
+    cue version || brew install cue-lang/tap/cue 
     jq --version || brew install jq
     ;;
 


### PR DESCRIPTION
Update the homebrew tap for CUE to use `cue-lang/tap/cue`

The current tap results in the following warning:
```
Warning: Use cue-lang/tap/cue instead of deprecated cuelang/tap/cue
```

Signed-off-by: Brad Beck <bradley.beck@gmail.com>