### PR TITLE
Make the Maven pipeline build less verbose

### DIFF
--- a/examples/maven/maven.yaml
+++ b/examples/maven/maven.yaml
@@ -29,6 +29,7 @@ spec:
       params:
         - name: GOALS
           value:
+            - --no-transfer-progress
             - -DskipTests
             - clean
             - package


### PR DESCRIPTION
The `--no-transfer-progress` flag suppresses the Maven download progress messages.

Signed-off-by: Brad Beck <bradley.beck@gmail.com>