### PR TITLE
Deploy Kyverno to check provenance of Tekton 

### DIFF
--- a/.github/workflows/install-ssf.yaml
+++ b/.github/workflows/install-ssf.yaml
@@ -39,15 +39,15 @@ jobs:
           make setup-minikube
       - name: Try the cluster !
         run: kubectl get pods -A
-      - name: Deploy SSF to minikube
-        run: |
-          make setup-tekton-chains
       - name: Generate temp keys
         run: |
           make tekton-generate-keys
       - name: Setup Kyverno
         run: |
           make setup-kyverno
+      - name: Setup Tekton Pipeline and Chains
+        run: |
+          make setup-tekton-chains
       - name: Run buildpacks pipeline
         run: |
           make example-buildpacks

--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ help: # Display help
 		}' $(MAKEFILE_LIST) | sort
 
 .PHONY: quickstart
-quickstart: setup-minikube setup-tekton-chains tekton-generate-keys setup-kyverno example-buildpacks ## Spin up the SSF project into minikube
+quickstart: setup-minikube tekton-generate-keys setup-kyverno setup-tekton-chains example-buildpacks ## Spin up the SSF project into minikube
 
 .PHONY: teardown
 teardown:

--- a/docs/content/docs/getting-started/quick-start.md
+++ b/docs/content/docs/getting-started/quick-start.md
@@ -48,7 +48,7 @@ make registry-proxy
 software factory. The next command will deploy and configure them:
 
 ```bash
-make setup-tekton-chains tekton-generate-keys setup-kyverno
+make tekton-generate-keys setup-kyverno setup-tekton-chains 
 ```
 
 ### Step 4: run a new pipeline

--- a/examples/go-pipeline/README.md
+++ b/examples/go-pipeline/README.md
@@ -17,7 +17,7 @@ auto determine the architecture.
 make setup-minikube
 
 # Setup tekton w/ chains
-make setup-tekton-chains tekton-generate-keys setup-kyverno
+make tekton-generate-keys setup-kyverno setup-tekton-chains
 
 # Run a new pipeline.
 make example-golang-pipeline

--- a/examples/gradle-pipeline/README.md
+++ b/examples/gradle-pipeline/README.md
@@ -11,7 +11,7 @@ This is a sample Gradle tekton pipeline.
 make setup-minikube
 
 # Setup tekton w/ chains
-make setup-tekton-chains tekton-generate-keys setup-kyverno
+make tekton-generate-keys setup-kyverno setup-tekton-chains
 
 # Run a new pipeline.
 make example-gradle-pipeline

--- a/examples/ibm-tutorial/README.md
+++ b/examples/ibm-tutorial/README.md
@@ -7,7 +7,7 @@
 make setup-minikube
 
 # Setup tekton w/ chains
-make setup-tekton-chains tekton-generate-keys setup-kyverno
+make tekton-generate-keys setup-kyverno setup-tekton-chains
 
 #### Begin local minikube registry
 ##

--- a/examples/maven/README.md
+++ b/examples/maven/README.md
@@ -11,7 +11,7 @@ This is a sample maven tekton pipeline.
 make setup-minikube
 
 # Setup tekton w/ chains
-make setup-tekton-chains tekton-generate-keys setup-kyverno
+make tekton-generate-keys setup-kyverno setup-tekton-chains
 
 # Run a new pipeline.
 make example-maven

--- a/examples/sample-pipeline/README.md
+++ b/examples/sample-pipeline/README.md
@@ -17,7 +17,7 @@ application.
 make setup-minikube
 
 # Setup tekton w/ chains
-make setup-tekton-chains tekton-generate-keys setup-kyverno
+make tekton-generate-keys setup-kyverno setup-tekton-chains
 
 # Run a new pipeline.
 make example-sample-pipeline

--- a/platform/00-kubernetes-minikube-setup.sh
+++ b/platform/00-kubernetes-minikube-setup.sh
@@ -34,7 +34,7 @@ COSIGN_RELEASE_URL="https://github.com/sigstore/cosign/releases/download/${COSIG
 COSIGN_CHECKSUMS="cosign_checksums.txt"
 COSIGN_ASSET="${COSIGN_BIN}-${COSIGN_OS}-${COSIGN_ARCH}"
 
-CUE_VERSION=v0.4.2
+CUE_VERSION=v0.4.3
 CUE_FILE_NAME=cue_${CUE_VERSION}_linux_amd64.tar.gz
 CUE_URL=https://github.com/cue-lang/cue/releases/download/${CUE_VERSION}
 CUE_CHECKSUMS=checksums.txt

--- a/platform/11-tekton-chains.sh
+++ b/platform/11-tekton-chains.sh
@@ -6,10 +6,7 @@ GIT_ROOT=$(git rev-parse --show-toplevel)
 # Setup tekton Chains
 
 # Install Chains.
-SECRETS=$(kubectl get secret signing-secrets -n tekton-chains -o jsonpath='{.immutable}' 2> /dev/null || true)
-if [ "$SECRETS" != "true" ]; then
-      kubectl apply --filename "$GIT_ROOT"/platform/vendor/tekton/chains/release.yaml
-fi
+kubectl apply --filename "$GIT_ROOT"/platform/vendor/tekton/chains/release.yaml || true
 kubectl rollout status -n tekton-chains deployment/tekton-chains-controller
 
 # Patch chains to generate in-toto provenance and store output in OCI

--- a/platform/vendor/tekton/pipeline/release.yaml
+++ b/platform/vendor/tekton/pipeline/release.yaml
@@ -42,9 +42,16 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
+  annotations:
+    seccomp.security.alpha.kubernetes.io/allowedProfileNames: 'docker/default,runtime/default'
+    seccomp.security.alpha.kubernetes.io/defaultProfileName: 'runtime/default'
+    apparmor.security.beta.kubernetes.io/allowedProfileNames: 'runtime/default'
+    apparmor.security.beta.kubernetes.io/defaultProfileName: 'runtime/default'
 spec:
   privileged: false
   allowPrivilegeEscalation: false
+  requiredDropCapabilities:
+    - ALL
   volumes:
     - 'emptyDir'
     - 'configMap'
@@ -54,6 +61,11 @@ spec:
   hostPID: false
   runAsUser:
     rule: 'MustRunAsNonRoot'
+  runAsGroup:
+    rule: 'MustRunAs'
+    ranges:
+      - min: 1
+        max: 65535
   seLinux:
     rule: 'RunAsAny'
   supplementalGroups:
@@ -117,10 +129,14 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
 rules:
-  # Read-write access to create Pods, K8s Events and PVCs (for Workspaces)
+  # Read-write access to create Pods and PVCs (for Workspaces)
   - apiGroups: [""]
-    resources: ["pods", "pods/log", "events", "persistentvolumeclaims"]
+    resources: ["pods", "persistentvolumeclaims"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  # Write permissions to publish events.
+  - apiGroups: [""]
+    resources: ["events"]
+    verbs: ["create", "update", "patch"]
   # Read-only access to these.
   - apiGroups: [""]
     resources: ["configmaps", "limitranges", "secrets", "serviceaccounts"]
@@ -129,6 +145,10 @@ rules:
   - apiGroups: ["apps"]
     resources: ["statefulsets"]
     verbs: ["get", "list", "create", "update", "delete", "patch", "watch"]
+  # Read-write access to ResolutionRequest for remote resolution.
+  - apiGroups: ["resolution.tekton.dev"]
+    resources: ["resolutionrequests"]
+    verbs: ["get", "list", "watch", "create", "delete"]
 ---
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -139,11 +159,24 @@ metadata:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
 rules:
-  # The webhook needs to be able to list and update customresourcedefinitions,
+  # The webhook needs to be able to get and update customresourcedefinitions,
   # mainly to update the webhook certificates.
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions", "customresourcedefinitions/status"]
-    verbs: ["get", "list", "update", "patch", "watch"]
+    verbs: ["get", "update", "patch"]
+    resourceNames:
+      - pipelines.tekton.dev
+      - pipelineruns.tekton.dev
+      - runs.tekton.dev
+      - tasks.tekton.dev
+      - clustertasks.tekton.dev
+      - taskruns.tekton.dev
+      - pipelineresources.tekton.dev
+      - conditions.tekton.dev
+  # knative.dev/pkg needs list/watch permissions to set up informers for the webhook.
+  - apiGroups: ["apiextensions.k8s.io"]
+    resources: ["customresourcedefinitions"]
+    verbs: ["list", "watch"]
   - apiGroups: ["admissionregistration.k8s.io"]
     # The webhook performs a reconciliation on these two resources and continuously
     # updates configuration.
@@ -518,8 +551,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.29.0"
-    version: "v0.29.0"
+    pipeline.tekton.dev/release: "v0.35.0"
+    version: "v0.35.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -598,8 +631,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.29.0"
-    version: "v0.29.0"
+    pipeline.tekton.dev/release: "v0.35.0"
+    version: "v0.35.0"
 spec:
   group: tekton.dev
   versions:
@@ -651,8 +684,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.29.0"
-    version: "v0.29.0"
+    pipeline.tekton.dev/release: "v0.35.0"
+    version: "v0.35.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -678,6 +711,24 @@ spec:
     - name: v1beta1
       served: true
       storage: true
+      # Opt into the status subresource so metadata.generation
+      # starts to increment
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          # One can use x-kubernetes-preserve-unknown-fields: true
+          # at the root of the schema (and inside any properties, additionalProperties)
+          # to get the traditional CRD behaviour that nothing is pruned, despite
+          # setting spec.preserveUnknownProperties: false.
+          #
+          # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+          # See issue: https://github.com/knative/serving/issues/912
+          x-kubernetes-preserve-unknown-fields: true
+    - name: v1
+      served: false
+      storage: false
       # Opt into the status subresource so metadata.generation
       # starts to increment
       subresources:
@@ -731,8 +782,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.29.0"
-    version: "v0.29.0"
+    pipeline.tekton.dev/release: "v0.35.0"
+    version: "v0.35.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -799,6 +850,37 @@ spec:
       # starts to increment
       subresources:
         status: {}
+    - name: v1
+      served: false
+      storage: false
+      schema:
+        openAPIV3Schema:
+          type: object
+          # One can use x-kubernetes-preserve-unknown-fields: true
+          # at the root of the schema (and inside any properties, additionalProperties)
+          # to get the traditional CRD behaviour that nothing is pruned, despite
+          # setting spec.preserveUnknownProperties: false.
+          #
+          # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+          # See issue: https://github.com/knative/serving/issues/912
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Succeeded
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
+        - name: StartTime
+          type: date
+          jsonPath: .status.startTime
+        - name: CompletionTime
+          type: date
+          jsonPath: .status.completionTime
+      # Opt into the status subresource so metadata.generation
+      # starts to increment
+      subresources:
+        status: {}
   names:
     kind: PipelineRun
     plural: pipelineruns
@@ -817,6 +899,106 @@ spec:
         service:
           name: tekton-pipelines-webhook
           namespace: tekton-pipelines
+
+---
+# Copyright 2022 The Tekton Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: resolutionrequests.resolution.tekton.dev
+  labels:
+    resolution.tekton.dev/release: devel
+spec:
+  group: resolution.tekton.dev
+  scope: Namespaced
+  names:
+    kind: ResolutionRequest
+    plural: resolutionrequests
+    singular: resolutionrequest
+    categories:
+      - all
+      - tekton
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      subresources:
+        status: {}
+      schema:
+        openAPIV3Schema:
+          type: object
+          properties:
+            spec:
+              description: Spec holds the parameters for the request.
+              type: object
+              properties:
+                params:
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+            status:
+              description: Status receives the data of a completed request.
+              type: object
+              properties:
+                data:
+                  description: The resolved contents of the requested resource in-lined as a string.
+                  type: string
+                annotations:
+                  description: Annotations is additional Status fields for the Resource to save some additional State as well as convey more information to the user. This is roughly akin to Annotations on any k8s resource, just the reconciler conveying richer information outwards.
+                  type: object
+                  x-kubernetes-preserve-unknown-fields: true
+                conditions:
+                  description: Conditions the latest available observations of a resource's current state.
+                  type: array
+                  items:
+                    description: Conditions describe the success and completion state of the resource request.
+                    type: object
+                    required:
+                      - status
+                      - type
+                    properties:
+                      lastTransitionTime:
+                        description: LastTransitionTime is the last time the condition transitioned from one status to another. We use VolatileTime in place of metav1.Time to exclude this from creating equality.Semantic differences (all other things held constant).
+                        type: string
+                        format: date-time
+                      message:
+                        description: A human readable message indicating details about the transition.
+                        type: string
+                      reason:
+                        description: The reason for the condition's last transition.
+                        type: string
+                      severity:
+                        description: Severity with which to treat failures of this type of condition. When this is not specified, it defaults to Error.
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        type: string
+                      type:
+                        description: Type of condition.
+                        type: string
+                observedGeneration:
+                  description: ObservedGeneration is the 'Generation' of the Service that was last processed by the controller.
+                  type: integer
+                  format: int64
+      additionalPrinterColumns:
+        - name: Succeeded
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Succeeded')].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type=='Succeeded')].reason"
 
 ---
 # Copyright 2019 The Tekton Authors
@@ -840,8 +1022,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.29.0"
-    version: "v0.29.0"
+    pipeline.tekton.dev/release: "v0.35.0"
+    version: "v0.35.0"
 spec:
   group: tekton.dev
   versions:
@@ -893,8 +1075,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.29.0"
-    version: "v0.29.0"
+    pipeline.tekton.dev/release: "v0.35.0"
+    version: "v0.35.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -902,6 +1084,37 @@ spec:
     - name: v1alpha1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          # One can use x-kubernetes-preserve-unknown-fields: true
+          # at the root of the schema (and inside any properties, additionalProperties)
+          # to get the traditional CRD behaviour that nothing is pruned, despite
+          # setting spec.preserveUnknownProperties: false.
+          #
+          # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+          # See issue: https://github.com/knative/serving/issues/912
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Succeeded
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
+        - name: StartTime
+          type: date
+          jsonPath: .status.startTime
+        - name: CompletionTime
+          type: date
+          jsonPath: .status.completionTime
+      # Opt into the status subresource so metadata.generation
+      # starts to increment
+      subresources:
+        status: {}
+    - name: v1beta1
+      served: false
+      storage: false
       schema:
         openAPIV3Schema:
           type: object
@@ -960,8 +1173,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.29.0"
-    version: "v0.29.0"
+    pipeline.tekton.dev/release: "v0.35.0"
+    version: "v0.35.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -987,6 +1200,24 @@ spec:
     - name: v1beta1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          # One can use x-kubernetes-preserve-unknown-fields: true
+          # at the root of the schema (and inside any properties, additionalProperties)
+          # to get the traditional CRD behaviour that nothing is pruned, despite
+          # setting spec.preserveUnknownProperties: false.
+          #
+          # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+          # See issue: https://github.com/knative/serving/issues/912
+          x-kubernetes-preserve-unknown-fields: true
+      # Opt into the status subresource so metadata.generation
+      # starts to increment
+      subresources:
+        status: {}
+    - name: v1
+      served: false
+      storage: false
       schema:
         openAPIV3Schema:
           type: object
@@ -1040,8 +1271,8 @@ metadata:
   labels:
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.29.0"
-    version: "v0.29.0"
+    pipeline.tekton.dev/release: "v0.35.0"
+    version: "v0.35.0"
 spec:
   group: tekton.dev
   preserveUnknownFields: false
@@ -1080,6 +1311,37 @@ spec:
     - name: v1beta1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          # One can use x-kubernetes-preserve-unknown-fields: true
+          # at the root of the schema (and inside any properties, additionalProperties)
+          # to get the traditional CRD behaviour that nothing is pruned, despite
+          # setting spec.preserveUnknownProperties: false.
+          #
+          # See https://kubernetes.io/blog/2019/06/20/crd-structural-schema/
+          # See issue: https://github.com/knative/serving/issues/912
+          x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - name: Succeeded
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].status"
+        - name: Reason
+          type: string
+          jsonPath: ".status.conditions[?(@.type==\"Succeeded\")].reason"
+        - name: StartTime
+          type: date
+          jsonPath: .status.startTime
+        - name: CompletionTime
+          type: date
+          jsonPath: .status.completionTime
+      # Opt into the status subresource so metadata.generation
+      # starts to increment
+      subresources:
+        status: {}
+    - name: v1
+      served: false
+      storage: false
       schema:
         openAPIV3Schema:
           type: object
@@ -1151,7 +1413,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.29.0"
+    pipeline.tekton.dev/release: "v0.35.0"
 # The data is populated at install time.
 ---
 apiVersion: admissionregistration.k8s.io/v1
@@ -1162,7 +1424,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.29.0"
+    pipeline.tekton.dev/release: "v0.35.0"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:
@@ -1181,7 +1443,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.29.0"
+    pipeline.tekton.dev/release: "v0.35.0"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:
@@ -1200,7 +1462,7 @@ metadata:
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
     app.kubernetes.io/part-of: tekton-pipelines
-    pipeline.tekton.dev/release: "v0.29.0"
+    pipeline.tekton.dev/release: "v0.35.0"
 webhooks:
   - admissionReviewVersions: ["v1"]
     clientConfig:
@@ -1415,10 +1677,16 @@ data:
     # label, the user's request supercedes.
     default-managed-by-label-value: "tekton-pipelines"
 
-    # default-pod-template contains the default pod template to use
-    # TaskRun and PipelineRun, if none is specified. If a pod template
-    # is specified, the default pod template is ignored.
+    # default-pod-template contains the default pod template to use for
+    # TaskRun and PipelineRun. If a pod template is specified on the
+    # PipelineRun, the default-pod-template is merged with that one.
     # default-pod-template:
+
+    # default-affinity-assistant-pod-template contains the default pod template
+    # to use for affinity assistant pods. If a pod template is specified on the
+    # PipelineRun, the default-affinity-assistant-pod-template is merged with
+    # that one.
+    # default-affinity-assistant-pod-template:
 
     # default-cloud-events-sink contains the default CloudEvents sink to be
     # used for TaskRun and PipelineRun, when no sink is specified.
@@ -1466,18 +1734,6 @@ data:
   # https://github.com/tektoncd/pipeline/blob/main/docs/workspaces.md#affinity-assistant-and-specifying-workspace-order-in-a-pipeline
   # or https://github.com/tektoncd/pipeline/pull/2630 for more info.
   disable-affinity-assistant: "false"
-  # Setting this flag to "false" will allow Tekton to override your
-  # Task container's $HOME environment variable.
-  #
-  # See https://github.com/tektoncd/pipeline/issues/2013 for more
-  # info.
-  disable-home-env-overwrite: "true"
-  # Setting this flag to "false" will allow Tekton to override your
-  # Task container's working directory.
-  #
-  # See https://github.com/tektoncd/pipeline/issues/1836 for more
-  # info.
-  disable-working-directory-overwrite: "true"
   # Setting this flag to "true" will prevent Tekton scanning attached
   # service accounts and injecting any credentials it finds into your
   # Steps.
@@ -1518,9 +1774,9 @@ data:
   # Setting this flag will determine which gated features are enabled.
   # Acceptable values are "stable" or "alpha".
   enable-api-fields: "stable"
-  # Setting this flag to "true" scopes when expressions to guard a Task only
-  # instead of a Task and its dependent Tasks.
-  scope-when-expressions-to-task: "false"
+  # Setting this flag to "true" enables CloudEvents for Runs, as long as a
+  # CloudEvents sink is configured in the config-defaults config map
+  send-cloudevents-for-runs: "false"
 
 ---
 # Copyright 2021 The Tekton Authors
@@ -1551,7 +1807,7 @@ data:
   # this ConfigMap such that even if we don't have access to
   # other resources in the namespace we still can have access to
   # this ConfigMap.
-  version: "v0.29.0"
+  version: "v0.35.0"
 
 ---
 # Copyright 2020 Tekton Authors LLC
@@ -1578,9 +1834,9 @@ metadata:
     app.kubernetes.io/part-of: tekton-pipelines
 data:
   # An inactive but valid configuration follows; see example.
-  leaseDuration: "15s"
-  renewDeadline: "10s"
-  retryPeriod: "2s"
+  lease-duration: "60s"
+  renew-deadline: "40s"
+  retry-period: "10s"
 
 ---
 # Copyright 2019 Tekton Authors LLC
@@ -1693,9 +1949,9 @@ data:
     # charge.  If metrics.backend-destination is not Stackdriver, this is
     # ignored.
     metrics.allow-stackdriver-custom-metrics: "false"
-    metrics.taskrun.level: "taskrun"
+    metrics.taskrun.level: "task"
     metrics.taskrun.duration-type: "histogram"
-    metrics.pipelinerun.level: "pipelinerun"
+    metrics.pipelinerun.level: "pipeline"
     metrics.pipelinerun.duration-type: "histogram"
 
 ---
@@ -1749,12 +2005,12 @@ metadata:
     app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/version: "v0.35.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v0.29.0"
+    pipeline.tekton.dev/release: "v0.35.0"
     # labels below are related to istio and should not be used for resource lookup
-    version: "v0.29.0"
+    version: "v0.35.0"
 spec:
   replicas: 1
   selector:
@@ -1769,13 +2025,13 @@ spec:
         app.kubernetes.io/name: controller
         app.kubernetes.io/component: controller
         app.kubernetes.io/instance: default
-        app.kubernetes.io/version: "v0.29.0"
+        app.kubernetes.io/version: "v0.35.0"
         app.kubernetes.io/part-of: tekton-pipelines
         # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-        pipeline.tekton.dev/release: "v0.29.0"
+        pipeline.tekton.dev/release: "v0.35.0"
         # labels below are related to istio and should not be used for resource lookup
         app: tekton-pipelines-controller
-        version: "v0.29.0"
+        version: "v0.35.0"
     spec:
       affinity:
         nodeAffinity:
@@ -1789,24 +2045,20 @@ spec:
       serviceAccountName: tekton-pipelines-controller
       containers:
         - name: tekton-pipelines-controller
-          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.29.0@sha256:72f79471f06d096cc53e51385017c9f0f7edbc87379bf415f99d4bd11cf7bc2b
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/controller:v0.35.0@sha256:1ba151e081bea043d82c684b4b63042a00886901bcb91a83db06325857b85e9c
           args: [
             # These images are built on-demand by `ko resolve` and are replaced
             # by image references by digest.
-            "-kubeconfig-writer-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v0.29.0@sha256:6d058f2203b9ab66f538cb586c7dc3b7cc31ae958a4135dd99e51799f24b06c9", "-git-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.29.0@sha256:c0b0ed1cd81090ce8eecf60b936e9345089d9dfdb6ebdd2fd7b4a0341ef4f2b9", "-entrypoint-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.29.0@sha256:66958b78766741c25e31954f47bc9fd53eaa28263506b262bf2cc6df04f18561", "-nop-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.29.0@sha256:6a037d5ba27d9c6be32a9038bfe676fb67d2e4145b4f53e9c61fb3e69f06e816", "-imagedigest-exporter-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.29.0@sha256:e38dd0d32253fce5aaf1e501c0bc71facc3720564b7e97055921cc5390d612e0", "-pr-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/pullrequest-init:v0.29.0@sha256:d28202fb8b33a1d4c05f261ef8dcbcdcf3b469887d4dad256ce91f73c917420e",
+            "-kubeconfig-writer-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/kubeconfigwriter:v0.35.0@sha256:9cb21a57f5f51813e54321f1cf20ae11e573d622ab8064f39cdfdff702905c1e", "-git-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.35.0@sha256:f98b666818a529e1fe6e7bb94cae77402ba0cabbf3a3fe00e4711d75b107472b", "-entrypoint-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/entrypoint:v0.35.0@sha256:5730032a7daf7526fae6b586badf849ffe4539e16fd8be927ec7e320564486be", "-nop-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/nop:v0.35.0@sha256:1d65a20cd5fbc79dc10e48ce9d2f7251736dac13b302b49a1c9a8717c5f2b5c5", "-imagedigest-exporter-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/imagedigestexporter:v0.35.0@sha256:c2e028e35a3c3a38e584bec51cb21483411eb8e0dd02c22c2f910c29df5892af", "-pr-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/pullrequest-init:v0.35.0@sha256:155f059340b19364ce2b6bd40ac565070885db8922dc6e9a52e0a7181747476a", "-workingdirinit-image", "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/workingdirinit:v0.35.0@sha256:f4dc5477599754b42261ce367ab5590ca7c7866f64e5381e894d11e43231c268",
             # This is gcr.io/google.com/cloudsdktool/cloud-sdk:302.0.0-slim
             "-gsutil-image", "gcr.io/google.com/cloudsdktool/cloud-sdk@sha256:27b2c22bf259d9bc1a291e99c63791ba0c27a04d2db0a43241ba0f1f20f4067f",
-            # The shell image must be root in order to create directories and copy files to PVCs.
-            # gcr.io/distroless/base:debug as of Apirl 17, 2021
+            # The shell image must allow root in order to create directories and copy files to PVCs.
+            # ghcr.io/distroless/busybox as of April 14 2022
             # image shall not contains tag, so it will be supported on a runtime like cri-o
-            "-shell-image", "gcr.io/distroless/base@sha256:aa4fd987555ea10e1a4ec8765da8158b5ffdfef1e72da512c7ede509bc9966c4",
+            "-shell-image", "ghcr.io/distroless/busybox@sha256:19f02276bf8dbdd62f069b922f10c65262cc34b710eea26ff928129a736be791",
             # for script mode to work with windows we need a powershell image
             # pinning to nanoserver tag as of July 15 2021
-            "-shell-image-win", "mcr.microsoft.com/powershell:nanoserver@sha256:b6d5ff841b78bdf2dfed7550000fd4f3437385b8fa686ec0f010be24777654d6",
-            # Experimental. Uncomment below to disable TaskRun and PipelineRun
-            # reconcilers' built-in taskRef and pipelineRef resolution procedures.
-            # "-experimental-disable-in-tree-resolution",
-          ]
+            "-shell-image-win", "mcr.microsoft.com/powershell:nanoserver@sha256:b6d5ff841b78bdf2dfed7550000fd4f3437385b8fa686ec0f010be24777654d6"]
           volumeMounts:
             - name: config-logging
               mountPath: /etc/config-logging
@@ -1817,16 +2069,6 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
-            # These phony AWS credentials are here to work around a bug in the aws go sdk
-            # that causes extremely long delays in the execution of tasks after the initial
-            # deployment of the Tekton Pipelines controller. See issue https://github.com/tektoncd/pipeline/issues/4087
-            # for more information.
-            - name: AWS_ACCESS_KEY_ID
-              value: foobarbaz
-            - name: AWS_SECRET_ACCESS_KEY
-              value: foobarbaz
-            - name: AWS_DEFAULT_REGION
-              value: foobarbaz
             # If you are changing these names, you will also need to update
             # the controller's Role in 200-role.yaml to include the new
             # values in the "configmaps" "get" rule.
@@ -1859,6 +2101,10 @@ spec:
             runAsUser: 65532
             runAsGroup: 65532
           ports:
+            - name: metrics
+              containerPort: 9090
+            - name: profiling
+              containerPort: 8008
             - name: probes
               containerPort: 8080
           livenessProbe:
@@ -1892,13 +2138,13 @@ metadata:
     app.kubernetes.io/name: controller
     app.kubernetes.io/component: controller
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/version: "v0.35.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v0.29.0"
+    pipeline.tekton.dev/release: "v0.35.0"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-controller
-    version: "v0.29.0"
+    version: "v0.35.0"
   name: tekton-pipelines-controller
   namespace: tekton-pipelines
 spec:
@@ -1907,6 +2153,9 @@ spec:
       port: 9090
       protocol: TCP
       targetPort: 9090
+    - name: http-profiling
+      port: 8008
+      targetPort: 8008
     - name: probes
       port: 8080
   selector:
@@ -1939,12 +2188,12 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/version: "v0.35.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v0.29.0"
+    pipeline.tekton.dev/release: "v0.35.0"
     # labels below are related to istio and should not be used for resource lookup
-    version: "v0.29.0"
+    version: "v0.35.0"
 spec:
   minReplicas: 1
   maxReplicas: 5
@@ -1985,12 +2234,12 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/version: "v0.35.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v0.29.0"
+    pipeline.tekton.dev/release: "v0.35.0"
     # labels below are related to istio and should not be used for resource lookup
-    version: "v0.29.0"
+    version: "v0.35.0"
 spec:
   replicas: 1
   selector:
@@ -2005,13 +2254,13 @@ spec:
         app.kubernetes.io/name: webhook
         app.kubernetes.io/component: webhook
         app.kubernetes.io/instance: default
-        app.kubernetes.io/version: "v0.29.0"
+        app.kubernetes.io/version: "v0.35.0"
         app.kubernetes.io/part-of: tekton-pipelines
         # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-        pipeline.tekton.dev/release: "v0.29.0"
+        pipeline.tekton.dev/release: "v0.35.0"
         # labels below are related to istio and should not be used for resource lookup
         app: tekton-pipelines-webhook
-        version: "v0.29.0"
+        version: "v0.35.0"
     spec:
       affinity:
         nodeAffinity:
@@ -2038,7 +2287,7 @@ spec:
         - name: webhook
           # This is the Go import path for the binary that is containerized
           # and substituted here.
-          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook:v0.29.0@sha256:46d5b90a7f4e9996351ad893a26bcbd27216676ad4d5316088ce351fb2c2c3dd
+          image: gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/webhook:v0.35.0@sha256:7244bf5e496347e2ed40347b152c0298b7ab87a16a24149691acea6f59bfde76
           # Resource request required for autoscaler to take any action for a metric
           resources:
             requests:
@@ -2110,13 +2359,13 @@ metadata:
     app.kubernetes.io/name: webhook
     app.kubernetes.io/component: webhook
     app.kubernetes.io/instance: default
-    app.kubernetes.io/version: "v0.29.0"
+    app.kubernetes.io/version: "v0.35.0"
     app.kubernetes.io/part-of: tekton-pipelines
     # tekton.dev/release value replaced with inputs.params.versionTag in pipeline/tekton/publish.yaml
-    pipeline.tekton.dev/release: "v0.29.0"
+    pipeline.tekton.dev/release: "v0.35.0"
     # labels below are related to istio and should not be used for resource lookup
     app: tekton-pipelines-webhook
-    version: "v0.29.0"
+    version: "v0.35.0"
   name: tekton-pipelines-webhook
   namespace: tekton-pipelines
 spec:

--- a/platform/vendor/vendor.yaml
+++ b/platform/vendor/vendor.yaml
@@ -1,8 +1,8 @@
 files:
-  - release_file: "https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.29.0/release.yaml"
-    rekor_uuid: "8ba5dcc45b9fad4d879a8b6815cdaa85fdee1d9fc24cf8811f103d537c602908"
+  - release_file: "https://storage.googleapis.com/tekton-releases/pipeline/previous/v0.35.0/release.yaml"
+    rekor_uuid: "b304386ca92d8a4ca0d2f0acf051a1557507acf4891f9bc9db60d604a1bf3791"
     destination_dir: "tekton/pipeline"
-    version: "v0.29.0"
+    version: "v0.35.0"
     validation_type: "rekor"
   - release_file: "https://storage.googleapis.com/tekton-releases/chains/previous/v0.8.0/release.yaml"
     rekor_uuid: "03e4be44d69a2697dc770c5aa3decd8fa945dcd8a4e6901bb109ccf1f4acb735"

--- a/resources/kyverno/admission-control-policy/admission-control-verify-attestation.cue
+++ b/resources/kyverno/admission-control-policy/admission-control-verify-attestation.cue
@@ -19,8 +19,27 @@ ssf: clusterPolicy: "attest-code-review": {
 				}]
 			}]
 			key: "{{ keys.data.ttlsh }}"
+		}, {
+			image: "gcr.io/tekton-releases/github.com/tektoncd/*"
+			attestations: [{
+				predicateType: "https://slsa.dev/provenance/v0.2"
+				conditions: [{
+					all: [{
+						key:      "{{ builder.id }}"
+						operator: "Equals"
+						value:    "https://tekton.dev/chains/v2"
+					}, {
+						key:      "{{ buildType }}"
+						operator: "Equals"
+						value:    "https://tekton.dev/attestations/chains@v2"
+					}]
+				}]
+			}]
+			key: "{{ keys.data.tektoncd }}"
 		}]
-		match: resources: namespaces: ["prod"]
+		match: resources: namespaces: ["tekton-pipelines",
+			"tekton-chains",
+			"prod"]
 	}]
 	metadata: annotations: "pod-policies.kyverno.io/autogen-controllers": "none"
 }

--- a/resources/kyverno/admission-control-policy/admission-control-verify-image.cue
+++ b/resources/kyverno/admission-control-policy/admission-control-verify-image.cue
@@ -31,7 +31,10 @@ ssf: clusterPolicy: "verify-image": {
 				-----END CERTIFICATE-----
 				"""
 		}]
-		match: resources: namespaces: ["default"]
+		match: resources: namespaces: ["tekton-pipelines",
+			"tekton-chains",
+			"default",
+			"prod"]
 	}]
 	metadata: annotations: {
 		"policies.kyverno.io/title":       "Verify Image"

--- a/scripts/gen-keys.sh
+++ b/scripts/gen-keys.sh
@@ -23,7 +23,7 @@ export NAMESPACE=tekton-chains
 export SECRET_NAME=signing-secrets
 : "${COSIGN_PASSWORD:=}"
 
+kubectl create namespace ${NAMESPACE} || true
 kubectl delete secret ${SECRET_NAME} -n ${NAMESPACE} || true
 echo "cosign generate-key-pair k8s://${NAMESPACE}/${SECRET_NAME}"
 cosign generate-key-pair k8s://${NAMESPACE}/${SECRET_NAME}
-kubectl delete po -n ${NAMESPACE} -l app=tekton-chains-controller || true


### PR DESCRIPTION
Signed-off-by: pxp928 <parth.psu@gmail.com>

Updated to deploy Kyverno first to check provenance of Tekton installation. Address initial trust the builder piece for Issue #182 
1. Updated kyverno policy
2. I had to update tekton pipelines in my branch as it fails the attestation policy check but can rebase once Brad's PR is merged.
3. Allow for build systems to be trusted before other pipelines are initiated